### PR TITLE
UI: fix wallet selector on mobile

### DIFF
--- a/src/modals/WalletModal/index.tsx
+++ b/src/modals/WalletModal/index.tsx
@@ -163,24 +163,21 @@ export default function WalletModal({
           return null
         }
 
-        if (!window.web3 && !window.ethereum && option.mobile) {
-          return (
-            <Option
-              onClick={() => {
-                tryActivation(option.connector)
-              }}
-              id={`connect-${key}`}
-              key={key}
-              active={option.connector && option.connector === connector}
-              color={option.color}
-              link={option.href}
-              header={option.name}
-              subheader={null}
-              icon={'/images/wallets/' + option.iconName}
-            />
-          )
-        }
-        return null
+        return (
+          <Option
+            onClick={() => {
+              tryActivation(option.connector)
+            }}
+            id={`connect-${key}`}
+            key={key}
+            active={option.connector && option.connector === connector}
+            color={option.color}
+            link={option.href}
+            header={option.name}
+            subheader={null}
+            icon={'/images/wallets/' + option.iconName}
+          />
+        )
       }
 
       // overwrite injected when needed


### PR DESCRIPTION
Hi Kasumi,

I want to apply for the bounty for issue #5 

It is now possible to view list of web3 wallet providers (Metamask, etc.) on mobile.
Test cases:
- disconnect account from metamask window, reload mistswap window, reject auto-connect attempts, click on "Connect to a wallet"
- in mistswap UI click on account, in popup click disconnect, "Select wallet" appears with a list of web3 providers

PE is seployed at https://mist.waifu.camp/swap (**very** slow)
