### PR TITLE
feat(ui): swap page now reflects the current exchange rate in the browser tab title

### DIFF
--- a/src/features/exchange-v1/swap/TradePrice.tsx
+++ b/src/features/exchange-v1/swap/TradePrice.tsx
@@ -16,21 +16,9 @@ interface TradePriceProps {
 export default function TradePrice({ price, showInverted, setShowInverted, className }: TradePriceProps) {
   const { i18n } = useLingui()
 
-  let formattedPrice: string
-
-  try {
-    formattedPrice = showInverted ? price.toSignificant(4) : price.invert()?.toSignificant(4)
-  } catch (error) {
-    formattedPrice = '0'
-  }
-
-  const label = showInverted ? `${price.quoteCurrency?.symbol}` : `${price.baseCurrency?.symbol} `
-
-  const labelInverted = showInverted ? `${price.baseCurrency?.symbol} ` : `${price.quoteCurrency?.symbol}`
-
   const flipPrice = useCallback(() => setShowInverted(!showInverted), [setShowInverted, showInverted])
 
-  const text = `${'1 ' + labelInverted + ' = ' + formattedPrice ?? '-'} ${label}`
+  const text = GetRateText({price, showInverted});
 
   return (
     <div
@@ -65,4 +53,27 @@ export default function TradePrice({ price, showInverted, setShowInverted, class
       </div>
     </div>
   )
+}
+
+export function GetRateText({ price, showInverted }) {
+  if (!price) {
+    return "";
+  }
+
+  let formattedPrice: string
+
+  try {
+    formattedPrice = showInverted ? price.toSignificant(4) : price.invert()?.toSignificant(4)
+  } catch (error) {
+    formattedPrice = '0'
+  }
+
+  const label = showInverted ? `${price.quoteCurrency?.symbol}` : `${price.baseCurrency?.symbol} `
+
+  const labelInverted = showInverted ? `${price.baseCurrency?.symbol} ` : `${price.quoteCurrency?.symbol}`
+
+
+  const text = `${'1 ' + labelInverted + ' = ' + formattedPrice ?? '-'} ${label}`
+
+  return text;
 }

--- a/src/pages/exchange/swap/[[...tokens]].tsx
+++ b/src/pages/exchange/swap/[[...tokens]].tsx
@@ -51,7 +51,7 @@ import MinerTip from '../../../features/exchange-v1/swap/MinerTip'
 import ProgressSteps from '../../../components/ProgressSteps'
 import SwapHeader from '../../../features/trade/Header'
 import TokenWarningModal from '../../../modals/TokenWarningModal'
-import TradePrice from '../../../features/exchange-v1/swap/TradePrice'
+import { default as TradePrice, GetRateText } from '../../../features/exchange-v1/swap/TradePrice'
 import Typography from '../../../components/Typography'
 import UnsupportedCurrencyFooter from '../../../features/exchange-v1/swap/UnsupportedCurrencyFooter'
 import Web3Connect from '../../../components/Web3Connect'
@@ -416,7 +416,7 @@ export default function Swap() {
   return (
     <Container id="swap-page" className="py-4 md:py-8 lg:py-12">
       <Head>
-        <title>{i18n._(t`MISTswap`)} | MISTswap</title>
+        <title>{GetRateText({price: trade?.executionPrice, showInverted}) || i18n._(t`MISTswap`)} | MISTswap</title>
         <meta
           key="description"
           name="description"


### PR DESCRIPTION
Address #12 
Title will show the exact rate as how the user did configure it for the swap, e.g. including swap direction and price impact due to volume