### PR TITLE
fix(ui): fix Swap UI crash when entering excessively large number

### DIFF
--- a/src/hooks/useV2Trades.ts
+++ b/src/hooks/useV2Trades.ts
@@ -43,21 +43,30 @@ export function useV2TradeExactIn(
   return useMemo(() => {
     if (currencyAmountIn && currencyOut && allowedPairs.length > 0) {
       if (maxHops === 1) {
-        return (
-          Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, {
+        let trade: Trade<Currency, Currency, TradeType.EXACT_INPUT> | null;
+        try {
+          trade = Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, {
             maxHops: 1,
             maxNumResults: 1,
           })[0] ?? null
-        )
+        } catch {
+          trade = null;
+        }
+        return ( trade )
       }
       // search through trades with varying hops, find best trade out of them
       let bestTradeSoFar: Trade<Currency, Currency, TradeType.EXACT_INPUT> | null = null
       for (let i = 1; i <= maxHops; i++) {
-        const currentTrade: Trade<Currency, Currency, TradeType.EXACT_INPUT> | null =
+        let currentTrade: Trade<Currency, Currency, TradeType.EXACT_INPUT> | null;
+        try {
+          currentTrade =
           Trade.bestTradeExactIn(allowedPairs, currencyAmountIn, currencyOut, {
             maxHops: i,
             maxNumResults: 1,
-          })[0] ?? null
+          })[0] ?? null;
+        } catch {
+          currentTrade = null;
+        }
         // if current trade is best yet, save it
         if (isTradeBetter(bestTradeSoFar, currentTrade, BETTER_TRADE_LESS_HOPS_THRESHOLD)) {
           bestTradeSoFar = currentTrade


### PR DESCRIPTION
Address #2
Wrapped the exception code in to a try-catch clause will a fallback to null.