### PR TITLE
feat(ui): adjust farm list appearance on mobile

### DIFF
--- a/src/features/onsen/FarmList.tsx
+++ b/src/features/onsen/FarmList.tsx
@@ -56,7 +56,7 @@ const FarmList = ({ farms, term }) => {
               (sortConfig.direction === 'descending' && <ChevronDownIcon width={12} height={12} />))}
         </div>
         <div
-          className="items-center justify-center hidden px-4 cursor-pointer md:flex hover:text-high-emphesis"
+          className="items-center justify-center px-4 cursor-pointer md:flex hover:text-high-emphesis"
           onClick={() => requestSort('pending')}
         >
           {i18n._(t`Pending`)}

--- a/src/features/onsen/FarmListItem.tsx
+++ b/src/features/onsen/FarmListItem.tsx
@@ -11,6 +11,7 @@ import { useLingui } from '@lingui/react'
 import { t } from '@lingui/macro'
 import { useCurrency } from '../../hooks/Tokens'
 import { usePendingSushi, useUserInfo } from './hooks'
+import { isMobile } from 'react-device-detect'
 
 const FarmListItem = ({ farm, ...rest }) => {
   const token0 = useCurrency(farm.pair.token0.id)
@@ -32,13 +33,13 @@ const FarmListItem = ({ farm, ...rest }) => {
           >
             <div className="grid grid-cols-5">
               <div className="flex col-span-2 space-x-4 md:col-span-1">
-                <DoubleLogo currency0={token0} currency1={token1} size={40} />
+                <DoubleLogo currency0={token0} currency1={token1} size={isMobile ? 30 : 40} />
                 <div className="flex flex-col justify-center">
                   <div>
-                    <span className="font-bold">{farm?.pair?.token0?.symbol}</span>/
-                    <span className={farm?.pair?.type === PairType.KASHI ? 'font-thin' : 'font-bold'}>
+                    <p className="font-bold">{farm?.pair?.token0?.symbol}</p>
+                    <p className={farm?.pair?.type === PairType.KASHI ? 'font-thin' : 'font-bold'}>
                       {farm?.pair?.token1?.symbol}
-                    </span>
+                    </p>
                   </div>
                 </div>
               </div>
@@ -73,8 +74,8 @@ const FarmListItem = ({ farm, ...rest }) => {
                 <div className="text-xs text-right md:text-base text-secondary">{i18n._(t`annualized`)}</div>
               </div>
               {pendingSushi && pendingSushi.greaterThan(ZERO) ? (
-                <div className="flex-row items-center hidden space-x-4 font-bold md:flex">
-                  <div className="flex items-center space-x-2">
+                <div className="flex flex-col items-center justify-center md:flex-row space-x-4 font-bold md:flex">
+                  <div className="hidden md:flex items-center space-x-2">
                     <div key="0" className="flex items-center">
                       <Image
                         src="https://raw.githubusercontent.com/mistswapdex/assets/master/blockchains/smartbch/assets/0x5fA664f69c2A4A3ec94FaC3cBf7049BD9CA73129/logo.png"
@@ -87,13 +88,13 @@ const FarmListItem = ({ farm, ...rest }) => {
                     </div>
                   </div>
                   <div className="flex flex-col space-y-1">
-                    <div key="0" className="text-xs md:text-sm whitespace-nowrap">
+                    <div key="0" className="text-xs md:text-sm">
                       {formatNumber(pendingSushi.toFixed(18))} MIST
                     </div>
                   </div>
               </div>
               ) : (
-                <div className="flex-row items-center hidden space-x-4 font-bold md:flex">
+                <div className="flex-row items-center justify-center flex pl-3 font-bold text-sm">
                   {i18n._(t`Stake LP to Farm`)}
                 </div>
               )}


### PR DESCRIPTION
Address #32

This PR:
- Makes pair images smaller on mobile
- Splits pair name into two lines
- Shows "Pending" tab on mobile in a compact way (without mist logo)

The formatting of TVL text itself is not changed.

Before:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/74184164/139803093-bc212a7c-9200-4870-9532-cda7a1aed154.png">


After:
<img width="327" alt="image" src="https://user-images.githubusercontent.com/74184164/139802976-ed1f6424-fff0-47a2-96b5-5d5b9cbb23b5.png">
