### PR TITLE
fix(ui): compact old ios

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -11,7 +11,7 @@ const Footer = () => {
   const { i18n } = useLingui()
   return (
     // <footer className="absolute bottom-0 flex items-center justify-between w-screen h-20 p-4 mx-auto text-center text-low-emphesis">
-    <footer className="flex-shrink-0 w-full">
+    <footer className="absolute left-0 w-full bottom-16 lg:bottom-0">
       <div className="flex items-center justify-between h-20 px-4">
         <Polling />
       </div>

--- a/src/components/Main/index.tsx
+++ b/src/components/Main/index.tsx
@@ -1,5 +1,5 @@
 const Main = ({ children }) => (
-  <main className="flex flex-col items-center justify-start flex-grow w-full h-full" style={{ height: 'max-content' }}>
+  <main className="flex flex-col items-center justify-start w-full" style={{ height: 'max-content' }}>
     {children}
   </main>
 )

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -47,7 +47,7 @@ export default function Modal({
                 }}
               >
                 <div className="w-full p-px rounded bg-gradient-to-r from-blue to-pink">
-                  <div className="flex flex-col w-full h-full p-6 overflow-y-hidden rounded bg-dark-900">
+                  <div className="flex flex-col w-full h-full p-6 overflow-y-auto overflow-x-auto rounded bg-dark-900">
                     <div style={{ minHeight: `${minHeight}vh`, maxHeight: `${maxHeight}vh` }}>{children}</div>
                   </div>
                 </div>

--- a/src/features/exchange-v1/swap/SwapModalHeader.tsx
+++ b/src/features/exchange-v1/swap/SwapModalHeader.tsx
@@ -46,7 +46,7 @@ export default function SwapModalHeader({
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <CurrencyLogo currency={trade.inputAmount.currency} size={48} />
-            <div className="overflow-ellipsis w-[220px] overflow-hidden font-bold text-2xl text-high-emphesis">
+            <div className="overflow-ellipsis md:w-[220px] overflow-hidden font-bold text-2xl text-high-emphesis">
               {trade.inputAmount.toSignificant(6)}
             </div>
           </div>
@@ -59,7 +59,7 @@ export default function SwapModalHeader({
           <div className="flex items-center gap-3">
             <CurrencyLogo currency={trade.outputAmount.currency} size={48} />
             <div
-              className={`overflow-ellipsis w-[220px] overflow-hidden font-bold text-2xl ${
+              className={`overflow-ellipsis md:w-[220px] overflow-hidden font-bold text-2xl ${
                 priceImpactSeverity > 2 ? 'text-red' : 'text-high-emphesis'
               }`}
             >

--- a/src/layouts/Default/index.tsx
+++ b/src/layouts/Default/index.tsx
@@ -6,7 +6,7 @@ import Popups from '../../components/Popups'
 
 const Layout = ({ children, banner = undefined }) => {
   return (
-    <div className="z-0 flex flex-col items-center w-full h-screen pb-16 lg:pb-0">
+    <div className="z-0 flex flex-col items-center w-full pb-32 lg:pb-16">
       {banner && <Banner />}
       <Header />
       <Main>{children}</Main>


### PR DESCRIPTION
Address #69 

fixed modal visibility issue on old IOS small device
optimize the swap modal style
the "smart scan area" become visible in mobile device now
tested on iPhone 6s IOS 14.2
